### PR TITLE
Fix Pixelit link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ yarn dev
 
 ## Thanks
 
-- Heavily inspired and adapted from [https://github.com/giventofly/pixelit](pixelit)
+- Heavily inspired and adapted from [https://github.com/giventofly/pixelit](https://github.com/giventofly/pixelit)
 - NES.css for being amazing
 
 ## License


### PR DESCRIPTION
Before it was linking to: https://github.com/SaraVieira/pixler/blob/main/pixelit

Now it links to the right repo: https://github.com/giventofly/pixelit