### PR TITLE
Revert canvas filters

### DIFF
--- a/overmind/effects.js
+++ b/overmind/effects.js
@@ -124,6 +124,8 @@ export const pixel = {
 
     Caman(drawTo, function () {
       const that = this;
+      that.revert();
+
       if (grayscale) {
         that.greyscale();
       }


### PR DESCRIPTION
Hi Sara! When applying a filter (e.g. grayscale) it's not possible to revert back to the original image - see for example https://github.com/SaraVieira/pixler/issues/4 . This is because the CamanJS filters are not being removed. 

I couldn't work out how to remove just one filter (possibly not a thing), but this added line will revert them all before reapplying - solving the above issue and also similar issues when applying/removing filters within the advanced settings of Pixelr. Perhaps not the most optimal solution but it does the job!